### PR TITLE
Don't hardcode ETH toolchain for bootrom compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ $(BOOTROM_DIR)/bootdata.cc: $(SCRIPTS_DIR)/generate_bootdata.py $(HJSON_OUT)
 
 $(BOOTROM_DIR)/bootrom.elf $(BOOTROM_DIR)/bootrom.dump $(BOOTROM_DIR)/bootrom.bin: \
   $(BOOTROM_DIR)/bootrom.S $(BOOTROM_DIR)/bootdata_bootrom.cc $(BOOTROM_DIR)/bootrom.ld Makefile
-	riscv -riscv64-gcc-9.5.0 riscv64-unknown-elf-gcc \
+	$(GCC_INSTALL_DIR)/bin/riscv32-unknown-elf-gcc \
 		-mabi=ilp32 -march=rv32imaf -static -nostartfiles \
 		-T$(BOOTROM_DIR)/bootrom.ld \
 		$(BOOTROM_DIR)/bootrom.S \
@@ -156,8 +156,8 @@ $(BOOTROM_DIR)/bootrom.elf $(BOOTROM_DIR)/bootrom.dump $(BOOTROM_DIR)/bootrom.bi
 		-I$(SPATZ_DIR)/hw/ip/snitch_test/src \
 		-I$(SOFTWARE_DIR)/snRuntime/include \
 		-o $(BOOTROM_DIR)/bootrom.elf
-	riscv -riscv64-gcc-9.5.0 riscv64-unknown-elf-objdump -D $(BOOTROM_DIR)/bootrom.elf > $(BOOTROM_DIR)/bootrom.dump
-	riscv -riscv64-gcc-9.5.0 riscv64-unknown-elf-objcopy -O binary $(BOOTROM_DIR)/bootrom.elf $(BOOTROM_DIR)/bootrom.bin
+	$(GCC_INSTALL_DIR)/bin/riscv32-unknown-elf-objdump -D $(BOOTROM_DIR)/bootrom.elf > $(BOOTROM_DIR)/bootrom.dump
+	$(GCC_INSTALL_DIR)/bin/riscv32-unknown-elf-objcopy -O binary $(BOOTROM_DIR)/bootrom.elf $(BOOTROM_DIR)/bootrom.bin
 
 $(BOOTROM_DIR)/bootrom.sv: $(BOOTROM_DIR)/bootrom.bin $(BOOTROM_DIR)/bootdata.cc
 	${PYTHON} $(SCRIPTS_DIR)/generate_bootrom.py \


### PR DESCRIPTION
@Aquaticfuller The riscv command is not available when building the toolchain using make toolchain. I hope this is also valid for the ETH toolchain?